### PR TITLE
Add Container Name into Pod Example

### DIFF
--- a/gen-apidocs/generators/examples/pod/pod.yaml
+++ b/gen-apidocs/generators/examples/pod/pod.yaml
@@ -6,6 +6,7 @@ sample: |
     name: pod-example
   spec:
     containers:
-    - image: ubuntu:trusty
+    - name: ubuntu
+      image: ubuntu:trusty
       command: ["echo"]
       args: ["Hello World"]


### PR DESCRIPTION
**what this PR does / why we need it**:

[pod-v1-core example](https://kubernetes.io/docs/api-reference/v1.8/#pod-v1-core) should have a container name so that the users can copy and run the example directly.

**Fixes** #33

**Release note:**

```release-note
None
```