### PR TITLE
Replace regular characters with HTML entities.

### DIFF
--- a/gen-apidocs/generators/api/definition.go
+++ b/gen-apidocs/generators/api/definition.go
@@ -146,6 +146,7 @@ type Definition struct {
 	// Api version of the definition (e.g. v1beta1)
 	Version ApiVersion
 	Kind    ApiKind
+	DescriptionWithEntities string
 
 	// InToc is true if this definition should appear in the table of contents
 	InToc        bool

--- a/gen-apidocs/generators/api/field.go
+++ b/gen-apidocs/generators/api/field.go
@@ -28,6 +28,7 @@ type Field struct {
 	Name        string
 	Type        string
 	Description string
+	DescriptionWithEntities string
 	// Optional Definition for complex types
 	Definition *Definition
 

--- a/gen-apidocs/generators/templates.go
+++ b/gen-apidocs/generators/templates.go
@@ -25,7 +25,7 @@ Group        | Version     | Kind
 
 {{if .OtherVersions}}<aside class="notice">Other api versions of this object exist: {{range $v := .OtherVersions}}{{$v.VersionLink}} {{end}}</aside>{{end}}
 
-{{.Description}}
+{{.DescriptionWithEntities}}
 
 {{if .AppearsIn}}<aside class="notice">
 Appears In:
@@ -36,7 +36,7 @@ Appears In:
 
 Field        | Description
 ------------ | -----------
-{{range $field := .Fields}}{{$field.Name}} {{if $field.Link}}<br /> *{{$field.Link}}* {{end}} {{if $field.PatchStrategy}}<br /> **patch type**: *{{$field.PatchStrategy}}* {{end}} {{if $field.PatchMergeKey}}<br /> **patch merge key**: *{{$field.PatchMergeKey}}* {{end}} | {{$field.Description}}
+{{range $field := .Fields}}{{$field.Name}} {{if $field.Link}}<br /> *{{$field.Link}}* {{end}} {{if $field.PatchStrategy}}<br /> **patch type**: *{{$field.PatchStrategy}}* {{end}} {{if $field.PatchMergeKey}}<br /> **patch merge key**: *{{$field.PatchMergeKey}}* {{end}} | {{$field.DescriptionWithEntities}}
 {{end}}
 {{end}}
 `
@@ -94,7 +94,7 @@ Group        | Version     | Kind
 {{if .Definition.OtherVersions}}<aside class="notice">Other api versions of this object exist: {{range $v := .Definition.OtherVersions}}{{$v.VersionLink}} {{end}}</aside>{{end}}
 
 
-{{.Definition.Description}}
+{{.Definition.DescriptionWithEntities}}
 
 {{if .Definition.AppearsIn}}<aside class="notice">
 Appears In:
@@ -105,7 +105,7 @@ Appears In:
 
 Field        | Description
 ------------ | -----------
-{{range $field := .Definition.Fields}}{{$field.Name}} {{if $field.Link}}<br /> *{{$field.Link}}* {{end}} {{if $field.PatchStrategy}}<br /> **patch type**: *{{$field.PatchStrategy}}* {{end}} {{if $field.PatchMergeKey}}<br /> **patch merge key**: *{{$field.PatchMergeKey}}* {{end}} | {{$field.Description}}
+{{range $field := .Definition.Fields}}{{$field.Name}} {{if $field.Link}}<br /> *{{$field.Link}}* {{end}} {{if $field.PatchStrategy}}<br /> **patch type**: *{{$field.PatchStrategy}}* {{end}} {{if $field.PatchMergeKey}}<br /> **patch merge key**: *{{$field.PatchMergeKey}}* {{end}} | {{$field.DescriptionWithEntities}}
 {{end}}
 
 {{if .Definition.Inline}}{{range $inline := .Definition.Inline}}### {{$inline.Name}} {{$inline.Version}} {{$inline.Group}}
@@ -119,7 +119,7 @@ Appears In:
 
 Field        | Description
 ------------ | -----------
-{{range $field := $inline.Fields}}{{$field.Name}} {{if $field.Link}}<br /> *{{$field.Link}}* {{end}} {{if $field.PatchStrategy}}<br /> **patch type**: *{{$field.PatchStrategy}}* {{end}} {{if $field.PatchMergeKey}}<br /> **patch merge key**: *{{$field.PatchMergeKey}}* {{end}} | {{$field.Description}}
+{{range $field := $inline.Fields}}{{$field.Name}} {{if $field.Link}}<br /> *{{$field.Link}}* {{end}} {{if $field.PatchStrategy}}<br /> **patch type**: *{{$field.PatchStrategy}}* {{end}} {{if $field.PatchMergeKey}}<br /> **patch merge key**: *{{$field.PatchMergeKey}}* {{end}} | {{$field.DescriptionWithEntities}}
 {{end}}
 {{end}}{{end}}
 


### PR DESCRIPTION
Addresses [kubernetes/kubernetes issue 57362](https://github.com/kubernetes/kubernetes/issues/57362).

[Related PR in kubernetes/website](https://github.com/kubernetes/website/pull/7038)

The [Kubernetes API reference docs](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/) are not rendering angle brackets in API element descriptions. So when a description includes a placeholder in angle brackets, the entire placeholder is missing from the rendered HTML.

For example, in the currently published reference docs, under [Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#toleration-v1-core), the description is missing some place holders that are in angle brackets.

The description should say this:

```
The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
```

But instead, is says this:

```
The pod this Toleration is attached to tolerates any taint that matches the triple using the matching operator .
```

This PR adjusts the doc generation code so that descriptions use HTML entities instead of actual angle brackets.

The Definition struct now has an additional field: DescriptionWithEntities.