### PR TITLE
Fix cross references in generated API references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,8 @@
 .idea/
 _generated_*.md
 gen-kubectldocs/generators/build/
-gen-kubectldocs/generators/v1_10/
 gen-kubectldocs/generators/includes/
-gen-kubectldocs/manifest.json
+gen-kubectldocs/generators/v1_10/
 gen-apidocs/generators/build/
 gen-apidocs/generators/includes/
 gen-apidocs/generators/manifest.json

--- a/gen-apidocs/generators/api/definition.go
+++ b/gen-apidocs/generators/api/definition.go
@@ -107,7 +107,7 @@ func (d *Definitions) InitializeFields(definition *Definition) {
 		field := &Field{
 			Name:        fieldName,
 			Type:        GetTypeName(property),
-			Description: def,
+			Description: escapeAsterisks(def),
 		}
 		if len(property.Extensions) > 0 {
 			if ps, f := property.Extensions.GetString(patchStrategyKey); f {
@@ -192,25 +192,38 @@ func (d *Definition) Key() string {
 }
 
 func (d *Definition) MdLink() string {
-	return fmt.Sprintf("[%s](#%s-%s-%s)", d.Name, strings.ToLower(d.Name), d.Version, d.Group)
+	groupName := strings.Replace(strings.ToLower(d.GroupFullName), ".", "-", -1)
+	return fmt.Sprintf("[%s](#%s-%s-%s)", d.Name, strings.ToLower(d.Name), d.Version, groupName)
 
 }
 
 func (d *Definition) HrefLink() string {
-	return fmt.Sprintf("<a href=\"#%s-%s-%s\">%s</a>", strings.ToLower(d.Name), d.Version, d.Group, d.Name)
+	groupName := strings.Replace(strings.ToLower(d.GroupFullName), ".", "-", -1)
+	return fmt.Sprintf("<a href=\"#%s-%s-%s\">%s</a>", strings.ToLower(d.Name), d.Version, groupName, d.Name)
 }
 
 func (d *Definition) FullHrefLink() string {
+	groupName := strings.Replace(strings.ToLower(d.GroupFullName), ".", "-", -1)
 	return fmt.Sprintf("<a href=\"#%s-%s-%s\">%s %s/%s</a>", strings.ToLower(d.Name),
-		d.Version, d.Group, d.Name, d.Group, d.Version)
+		d.Version, groupName, d.Name, d.Group, d.Version)
 }
 
 func (d *Definition) VersionLink() string {
-	return fmt.Sprintf("<a href=\"#%s-%s-%s\">%s</a>", strings.ToLower(d.Name), d.Version, d.Group, d.Version)
+	groupName := strings.Replace(strings.ToLower(d.GroupFullName), ".", "-", -1)
+	return fmt.Sprintf("<a href=\"#%s-%s-%s\">%s</a>", strings.ToLower(d.Name), d.Version, groupName, d.Version)
+}
+
+// handle '*', 'a/*', '*/b', '*/*' cases
+func escapeAsterisks(des string) string {
+	s := strings.Replace(des, "'*'", `'\*'`, -1)
+	s = strings.Replace(s, "/*'", `/\*'`, -1)
+	s = strings.Replace(s, "'*/", `'\*/`, -1)
+	s = strings.Replace(s, "'*/*'", `'\*/\*'`, -1)
+	return s
 }
 
 func (d Definition) Description() string {
-	return d.schema.Description
+	return escapeAsterisks(d.schema.Description)
 }
 
 // TODO: Rework this function because it is ugly

--- a/gen-apidocs/generators/config.yaml
+++ b/gen-apidocs/generators/config.yaml
@@ -98,7 +98,7 @@ resource_categories:
       version: v1
       group: core
     - name: VolumeAttachment
-      version: v1alpha1
+      version: v1beta1
       group: storage
   - name: "Metadata Apis"
     include: "meta"
@@ -148,7 +148,7 @@ resource_categories:
     include: "cluster"
     resources:
     - name: APIService
-      version: v1beta1
+      version: v1
       group: apiregistration
     - name: Binding
       version: v1

--- a/gen-apidocs/generators/templates.go
+++ b/gen-apidocs/generators/templates.go
@@ -17,13 +17,13 @@ limitations under the License.
 package generators
 
 var DefinitionTemplate = `
-{{define "definition.template"}}##` + "`{{.Name}}` [`{{.GroupDisplayName}}`/`{{.Version}}`]" + `
+{{define "definition.template"}}## {{.Name}} {{.Version}} {{.Group}}
 
 Group        | Version     | Kind
 ------------ | ---------- | -----------
 ` + "`{{.GroupDisplayName}}` | `{{.Version}}` | `{{.Name}}`" + `
 
-{{if .OtherVersions}}<aside class="notice">Other api versions of this object exist: {{range $v := .OtherVersions}}{{$v.VersionLink}} {{end}}</aside>{{end}}
+{{if .OtherVersions}}<aside class="notice">Other API versions of this object exist: {{range $v := .OtherVersions}}{{$v.VersionLink}} {{end}}</aside>{{end}}
 
 {{.DescriptionWithEntities}}
 
@@ -73,7 +73,7 @@ Code         | Description
 {{define "concept.template"}}
 
 -----------
-# {{.Name}} [{{if .Definition.ShowGroup}}{{.Definition.GroupDisplayName}}/{{end}}{{.Definition.Version}}] 
+# {{.Name}} {{.Definition.Version}} {{if .Definition.ShowGroup}}{{.Definition.GroupDisplayName}}{{end}} 
 
 {{if .Definition.Sample.Sample}}{{$n := .Definition.Sample.Note}}{{range $e := .Definition.GetSamples}}>{{$e.Tab}} {{$n}}
 


### PR DESCRIPTION
In previous commit, we have enabled the API reference doc to show full
group names, however, due to implementation constraints (the use of
brodocs docker image), the reformatted H1 headers are not producing
anchor IDs properly. This PR reverses the H1 header generated.
Other issues fixed:

- .gitignore pointing to some non-existent files/dirs
- config.yaml was using v1alpha1 version of VolumeAttachment as default,
  so the navigation bar is not working properly.
- config.yaml was using v1beta1 version of APIService which prevents the
  navigation bar from working properly.
- Added handler to special character sequences such as '*', '*/scale',
  'pods/*' and '*/*' which had been incorrectly translated into <em>
  by the markdown Node.js module.
- Other links fixed for cross-references.

Will continue digging how to simplify the reference doc generation.