### PR TITLE
Fix for release 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - 1.10.1
+  - 1.10.2
 
 install:
 - export PATH=$GOPATH/bin:$PATH
@@ -9,14 +9,11 @@ install:
 
 # Checkout the correct version of kubernetes and build generated files, and then
 # vendor all packages for resolving dependencies.
-- pushd $GOPATH/src/k8s.io/kubernetes && git checkout release-1.10 && make generated_files && cp -L -R vendor $GOPATH/src && rm -r vendor && popd
+- pushd $GOPATH/src/k8s.io/kubernetes && git checkout release-1.11 && make generated_files && cp -L -R vendor $GOPATH/src && rm -r vendor && popd
 
 # Fetch other dependencies if any
 - go get -v github.com/kubernetes-incubator/reference-docs/gen-compdocs
 
-# - pushd $GOPATH/src/k8s.io/kubernetes && git checkout release-1.10 && make depended_files && popd
-# - cp -L -R $GOPATH/src/k8s.io/kubernetes/vendor/ $GOPATH/src/
-#  - rm -r $GOPATH/src/k8s.io/kubernetes/vendor/
 # TODO: update API spec
 
 script:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 WEBROOT=~/src/github.com/kubernetes/website
 K8SROOT=~/src/github.com/kubernetes/kubernetes
-MINOR_VERSION=10
+MINOR_VERSION=11
 
 APISRC=gen-apidocs/generators/build
 APIDST=$(WEBROOT)/docs/reference/generated/kubernetes-api/v1.$(MINOR_VERSION)

--- a/gen-compdocs/generators/doc.go
+++ b/gen-compdocs/generators/doc.go
@@ -207,7 +207,7 @@ func flagUsages(f *pflag.FlagSet) string {
 
 	lines := make([]string, 0)
 
-	lines = append(lines, "<table style=\"width: 100%%;\">\n  <colgroup>\n" +
+	lines = append(lines, "<table style=\"width: 100%%; table-layout: fixed;\">\n  <colgroup>\n" +
 		"    <col span=\"1\" style=\"width: 10px;\" />\n" +
 		"    <col span=\"1\" />\n" +
 		"  </colgroup>\n" +
@@ -253,7 +253,7 @@ func flagUsages(f *pflag.FlagSet) string {
 				line += fmt.Sprintf("&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: %s", flag.DefValue)
 			}
 		}
-		line += "</td>\n    </tr>\n    <tr>\n      <td></td><td style=\"line-height: 130%%\">"
+		line += "</td>\n    </tr>\n    <tr>\n      <td></td><td style=\"line-height: 130%%; word-wrap: break-word;\">"
 
 		// escape '<' and '>', force wrap for "\n"
 		usage = strings.Replace(usage, "<", "&lt;", -1)

--- a/gen-compdocs/generators/gen_kube_docs.go
+++ b/gen-compdocs/generators/gen_kube_docs.go
@@ -39,9 +39,10 @@ func GenerateFiles(path, module string) {
 		os.Exit(1)
 	}
 
+	stop := make(chan struct{})
 	switch module {
 	case "kube-apiserver":
-		apiserver := apiservapp.NewAPIServerCommand()
+		apiserver := apiservapp.NewAPIServerCommand(stop)
 		GenMarkdownTree(apiserver, outDir, true)
 
 	case "kube-controller-manager":
@@ -61,7 +62,7 @@ func GenerateFiles(path, module string) {
 		GenMarkdownTree(scheduler, outDir, true)
 
 	case "kubelet":
-		kubelet := kubeletapp.NewKubeletCommand()
+		kubelet := kubeletapp.NewKubeletCommand(stop)
 		GenMarkdownTree(kubelet, outDir, true)
 
 	case "kubeadm":


### PR DESCRIPTION

This PR includes the following improvement/revisions:
    
    - update .travis.yml to use go1.10.2
    - update .travis.yml to use release-1.11 branch of kubernetes
    - revise invocation to kube-apiserver and kubelet command which now
      requires a stop channel.
    - update the style of the generated table with "table-layout: fixed" so
      that the table won't run beyond screen width under Hugo
    - updated style of the cell in the generated table so it will do a word
      based line wrapping.
