### PR TITLE
Fix kubectl reference doc generation for release-1.11

### DIFF
--- a/gen-kubectldocs/generators/.gitignore
+++ b/gen-kubectldocs/generators/.gitignore
@@ -1,0 +1,1 @@
+manifest.json

--- a/gen-kubectldocs/generators/read_cmd.go
+++ b/gen-kubectldocs/generators/read_cmd.go
@@ -17,20 +17,20 @@ limitations under the License.
 package generators
 
 import (
-	"io/ioutil"
-	"os"
+	// "io/ioutil"
+	// "os"
 	"sort"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	"k8s.io/kubernetes/pkg/kubectl/cmd"
-	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	// cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 )
 
 func GetSpec() KubectlSpec {
 	// Initialize a kubectl command that we can use to get the help documentation
-	kubectl := cmd.NewKubectlCommand(cmdutil.NewFactory(nil), os.Stdin, ioutil.Discard, ioutil.Discard)
+	kubectl := cmd.NewDefaultKubectlCommand()
 
 	// Create the structural representation
 	return NewKubectlSpec(kubectl)

--- a/gen-kubectldocs/generators/v1_11/static_includes/_app_management.md
+++ b/gen-kubectldocs/generators/v1_11/static_includes/_app_management.md
@@ -1,0 +1,4 @@
+# <strong>APP MANAGEMENT</strong>
+
+This section contains commands for creating, updating, deleting, and
+viewing your workloads in a Kubernetes cluster.

--- a/gen-kubectldocs/generators/v1_11/static_includes/_getting_started.md
+++ b/gen-kubectldocs/generators/v1_11/static_includes/_getting_started.md
@@ -1,0 +1,11 @@
+# <strong>GETTING STARTED</strong>
+
+This section contains the most basic commands for getting a workload
+running on your cluster.
+
+- `run` will start running 1 or more instances of a container image on your cluster.
+- `expose` will load balance traffic across the running instances, and can create a HA proxy for accessing the containers from outside the cluster.
+
+Once your workloads are running, you can use the commands in the
+[WORKING WITH APPS](#-strong-working-with-apps-strong-) section to
+inspect them.

--- a/gen-kubectldocs/generators/v1_11/static_includes/_working_with_apps.md
+++ b/gen-kubectldocs/generators/v1_11/static_includes/_working_with_apps.md
@@ -1,0 +1,8 @@
+# <strong>WORKING WITH APPS</strong>
+
+This section contains commands for inspecting and debugging your
+applications.
+
+- `logs` will print the logs from the specified pod + container.
+- `exec` can be used to get an interactive shell on a pod + container.
+- `describe` will print debug information about the given resource.

--- a/gen-kubectldocs/generators/v1_11/toc.yaml
+++ b/gen-kubectldocs/generators/v1_11/toc.yaml
@@ -1,0 +1,59 @@
+categories:
+- name: GETTING STARTED
+  include: _getting_started.md
+  commands:
+  - create
+  - get
+  - run
+  - expose
+  - delete
+- name: APP MANAGEMENT
+  include: _app_management.md
+  commands:
+  - apply
+  - annotate
+  - autoscale
+  - convert
+  - edit
+  - label
+  - patch
+  - replace
+  - rollout
+  - scale
+  - set
+  - wait
+- name: WORKING WITH APPS
+  include: _working_with_apps.md
+  commands:
+  - attach
+  - auth
+  - cp
+  - describe
+  - exec
+  - logs
+  - port-forward
+  - proxy
+  - top
+- name: CLUSTER MANAGEMENT
+  commands:
+  - api-versions
+  - certificate
+  - cluster-info
+  - cordon
+  - drain
+  - taint
+  - uncordon
+- name: KUBECTL SETTINGS AND USAGE
+  commands:
+  - alpha
+  - api-resources
+  - completion
+  - config
+  - explain
+  - options
+  - plugin
+  - version
+- name: DEPRECATED COMMANDS
+  commands:
+  - rolling-update
+  - run-container


### PR DESCRIPTION
- The call to create kubectl command has changed, this has been adapted.
- The run-container and rolling-update commands are deprecated.
- A new api-resources command has been added.