### PR TITLE
Add kubectl to be part of kube-comp doc generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ comp: cleancomp
 	go run gen-compdocs/main.go gen-compdocs/build kubelet
 	go run gen-compdocs/main.go gen-compdocs/build kube-proxy
 	go run gen-compdocs/main.go gen-compdocs/build kubeadm
+	go run gen-compdocs/main.go gen-compdocs/build kubectl
 
 copycomp:
 	cp $(shell pwd)/gen-compdocs/build/* $(WEBROOT)/docs/reference/generated/

--- a/gen-compdocs/generators/gen_kube_docs.go
+++ b/gen-compdocs/generators/gen_kube_docs.go
@@ -29,6 +29,7 @@ import (
 	schapp "k8s.io/kubernetes/cmd/kube-scheduler/app"
 	kubeadmapp "k8s.io/kubernetes/cmd/kubeadm/app/cmd"
 	kubeletapp "k8s.io/kubernetes/cmd/kubelet/app"
+	kubectlcmd "k8s.io/kubernetes/pkg/kubectl/cmd"
 )
 
 func GenerateFiles(path, module string) {
@@ -78,6 +79,10 @@ func GenerateFiles(path, module string) {
 
 		// cleanup generated code for usage as include in the website
 		MarkdownPostProcessing(kubeadm, outDir, cleanupForInclude)
+
+	case "kubectl":
+		kubectl := kubectlcmd.NewDefaultKubectlCommand()
+		GenMarkdownTree(kubectl, outDir, true)
 
 	default:
 		fmt.Fprintf(os.Stderr, "Module %s is not supported", module)


### PR DESCRIPTION
Have kubectl reference docs generated as other kube components such as kube-apiserver. This is a feasibility test to generate kubectl ref docs like kubeadm.