### PR TITLE
Fix links in the API reference generator

### DIFF
--- a/gen-apidocs/generators/api/definition.go
+++ b/gen-apidocs/generators/api/definition.go
@@ -207,7 +207,8 @@ func (d *Definition) Key() string {
 }
 
 func (d *Definition) LinkID() string {
-	link := fmt.Sprintf("%s-%s-%s", d.Name, d.Version, d.Group)
+	groupName := strings.Replace(strings.ToLower(d.GroupFullName), ".", "-", -1)
+	link := fmt.Sprintf("%s-%s-%s", d.Name, d.Version, groupName)
 	return strings.ToLower(link)
 }
 
@@ -222,7 +223,7 @@ func (d *Definition) HrefLink() string {
 }
 
 func (d *Definition) FullHrefLink() string {
-	groupName := strings.Replace(strings.ToLower(string(d.Group)), ".", "-", -1)
+	groupName := strings.Replace(strings.ToLower(d.GroupFullName), ".", "-", -1)
 	return fmt.Sprintf("<a href=\"#%s-%s-%s\">%s [%s/%s]</a>", strings.ToLower(d.Name),
 		d.Version, groupName, d.Name, d.Group, d.Version)
 }

--- a/gen-apidocs/generators/html.go
+++ b/gen-apidocs/generators/html.go
@@ -157,7 +157,7 @@ func (h *HTMLWriter) WriteDefinition(d *api.Definition) {
 		os.Stderr.WriteString(fmt.Sprintf("%v", err))
 		os.Exit(1)
 	}
-	nvg := fmt.Sprintf("%s %s %s", d.Name, d.Version, d.Group)
+	nvg := fmt.Sprintf("%s %s %s", d.Name, d.Version, d.GroupDisplayName())
 	linkID := getLink(nvg)
 	fmt.Fprintf(f, "<H2 id=\"%s\">%s</H2>\n", linkID, nvg)
 	fmt.Fprintf(f, "<TABLE class=\"col-md-8\">\n<THEAD><TR><TH>Group</TH><TH>Version</TH><TH>Kind</TH></TR></THEAD>\n<TBODY>\n")


### PR DESCRIPTION
Fix links generated in the API reference. The inconsistent full-group names are causing links missed in the generated doc.