### PR TITLE
Update API reference generator for 1.16

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 WEBROOT=~/src/github.com/kubernetes/website
 K8SROOT=~/k8s/src/k8s.io/kubernetes
-MINOR_VERSION=15
+MINOR_VERSION=16
 
 APISRC=gen-apidocs/generators
 APIDST=$(WEBROOT)/static/docs/reference/generated/kubernetes-api/v1.$(MINOR_VERSION)

--- a/gen-apidocs/generators/api/config.go
+++ b/gen-apidocs/generators/api/config.go
@@ -477,6 +477,27 @@ func (c *Config) mapOperationsToDefinitions() {
 			continue
 		}
 
+		// XXX: The TokenRequest definition has operation defined as "createCoreV1NamespacedServiceAccountToken"!
+		if d.Name == "TokenRequest" && d.Group.String() == "authentication" && d.Version == "v1" {
+			operationId := "createCoreV1NamespacedServiceAccountToken"
+			if o, ok := c.Operations[operationId]; ok {
+				ot := OperationType {
+					Name: "Create",
+					Match: "createCoreV1NamespacedServiceAccountToken",
+				}
+				oc := OperationCategory {
+					Name: "Write Operations",
+					OperationTypes: []OperationType { ot, },
+				}
+
+				o.Definition = d
+				o.Definition.InToc = true
+				o.initExample(c)
+				oc.Operations = append(oc.Operations, o)
+			}
+			continue
+		}
+
 		for i := range c.OperationCategories {
 			oc := c.OperationCategories[i]
 			for j := range oc.OperationTypes {

--- a/gen-apidocs/generators/api/operation.go
+++ b/gen-apidocs/generators/api/operation.go
@@ -97,10 +97,10 @@ func VisitOperations(specs []*loads.Document, fn func(operation Operation)) {
 }
 
 func IsBlacklistedOperation(o *spec.Operation) bool {
-	return false
-	// return strings.HasSuffix(o.ID, "APIGroup") || // These are just the API group meta datas.  Ignore for now.
-		// strings.HasSuffix(o.ID, "APIResources") || // These are just the API group meta datas.  Ignore for now.
-		// strings.HasSuffix(o.ID, "APIVersions") // || // These are just the API group meta datas.  Ignore for now.
+	// return false
+	return strings.HasSuffix(o.ID, "APIGroup") || // These are just the API group meta datas.  Ignore for now.
+		strings.HasSuffix(o.ID, "APIResources") || // These are just the API group meta datas.  Ignore for now.
+		strings.HasSuffix(o.ID, "APIVersions") // || // These are just the API group meta datas.  Ignore for now.
 		//strings.HasPrefix(o.ID, "connect") || // Skip pod connect apis for now.  There are too many.
 		//strings.HasPrefix(o.ID, "proxy")
 }

--- a/gen-apidocs/generators/config.yaml
+++ b/gen-apidocs/generators/config.yaml
@@ -12,6 +12,7 @@ api_groups:
   - "Certificates"
   - "Coordination"
   - "Core"
+  - "Discovery"
   - "Extensions"
   - "Meta"
   - "Networking"
@@ -62,6 +63,9 @@ resource_categories:
     - name: Endpoints
       version: v1
       group: core
+    - name: EndpointSlice
+      version: v1alpha1
+      group: discovery
     - name: Ingress
       version: v1beta1
       group: networking
@@ -103,7 +107,7 @@ resource_categories:
       version: v1
       group: apps
     - name: CustomResourceDefinition
-      version: v1beta1
+      version: v1
       group: apiextensions
     - name: Event
       version: v1
@@ -115,10 +119,10 @@ resource_categories:
       version: v1
       group: autoscaling
     - name: MutatingWebhookConfiguration
-      version: v1beta1
+      version: v1
       group: admissionregistration
     - name: ValidatingWebhookConfiguration
-      version: v1beta1
+      version: v1
       group: admissionregistration
     - name: PodTemplate
       version: v1
@@ -200,6 +204,9 @@ resource_categories:
     - name: SubjectAccessReview
       version: v1
       group: authorization
+    - name: TokenRequest
+      version: v1
+      group: authentication
     - name: TokenReview
       version: v1
       group: authentication


### PR DESCRIPTION
There are some changes to the top-level API resources in 1.16. One of the weird change is about the newly added `TokenRequest` resource definition where the sole operation defined for it is called `CreateCoreV1NamespacedServiceAccountToken`. Why we are creating a resource type named `Potato` and adding an operation called `CookMushroom`? Sigh.